### PR TITLE
Add Uniswap Market to BKN

### DIFF
--- a/src/config/token_data.py
+++ b/src/config/token_data.py
@@ -533,7 +533,9 @@ TOKENS = {
       "name": "Brickken (Portal)",
       "sourceAddress": "0x0A638F07ACc6969abF392bB009f216D22aDEa36d",
       "coingeckoId": "brickken",
-      "markets": {},
+      "markets": {
+        "eth": ["uniswap"]
+      },
       "logo": "https://etherscan.io/token/images/brickken_32.png",
       "destinations": {
         "bsc": {

--- a/src/markets.json
+++ b/src/markets.json
@@ -1966,6 +1966,11 @@
         }
       },
       "2": {
+        "0x0e28bC9B03971E95acF9ae1326E51ecF9C55B498": {
+          "markets": [
+            "uniswap"
+          ]
+        },
         "0x3413a030EF81a3dD5a302F4B4D11d911e12ed337": {
           "markets": [
             "curve"


### PR DESCRIPTION
This adds Uniswap as market for Ethereum chain for the BKN token